### PR TITLE
Add skip-name-resolve to workaround too-long hostname panic

### DIFF
--- a/etc/templates/my.cnf.tmpl
+++ b/etc/templates/my.cnf.tmpl
@@ -84,6 +84,7 @@ innodb_log_file_size = 32M
 innodb_additional_mem_pool_size = 8M
 innodb_flush_log_at_trx_commit = 1
 
+skip-name-resolve = 1
 # Instead of skip-networking the default is now to listen only on
 # localhost which is more compatible and is not less secure.
 # bind-address	= 127.0.0.1


### PR DESCRIPTION
See https://github.com/laincloud/mysql-resource/issues/1
